### PR TITLE
增加支持自定义SMTP服务器的设置

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -76,6 +76,7 @@ jobs:
         EMAIL_USER: ${{ secrets.EMAIL_USER }}
         EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
         EMAIL_TO: ${{ secrets.EMAIL_TO }}
+        CUSTOM_SMTP_SERVER: ${{ secrets.CUSTOM_SMTP_SERVER }}
         PUSHPLUS_TOKEN: ${{ secrets.PUSHPLUS_TOKEN }}
         SERVERPUSHKEY: ${{ secrets.SERVERPUSHKEY }}
         FEISHU_WEBHOOK: ${{ secrets.FEISHU_WEBHOOK }}

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@
 ### 邮箱通知
 - `EMAIL_USER`: 发件人邮箱地址
 - `EMAIL_PASS`: 发件人邮箱密码/授权码
+- `CUSTOM_SMTP_SERVER`: 自定义发件人SMTP服务器(可选)
 - `EMAIL_TO`: 收件人邮箱地址
-
 ### 钉钉机器人
 - `DINGDING_WEBHOOK`: 钉钉机器人的 Webhook 地址
 

--- a/notify.py
+++ b/notify.py
@@ -12,6 +12,7 @@ class NotificationKit:
 		self.email_user: str = os.getenv('EMAIL_USER', '')
 		self.email_pass: str = os.getenv('EMAIL_PASS', '')
 		self.email_to: str = os.getenv('EMAIL_TO', '')
+		self.smtp_server: str = os.getenv('CUSTOM_SMTP_SERVER', '')
 		self.pushplus_token = os.getenv('PUSHPLUS_TOKEN')
 		self.server_push_key = os.getenv('SERVERPUSHKEY')
 		self.dingding_webhook = os.getenv('DINGDING_WEBHOOK')
@@ -30,7 +31,7 @@ class NotificationKit:
 		body = MIMEText(content, msg_type, 'utf-8')
 		msg.attach(body)
 
-		smtp_server = f'smtp.{self.email_user.split("@")[1]}'
+		smtp_server = self.smtp_server if self.smtp_server else f'smtp.{self.email_user.split("@")[1]}'
 		with smtplib.SMTP_SSL(smtp_server, 465) as server:
 			server.login(self.email_user, self.email_pass)
 			server.send_message(msg)


### PR DESCRIPTION
Hi Milly,

我增加了对于自定义SMTP服务器的设置.可能有用户使用类似forwardmail这种邮箱提供商(比如我)自定义了一个别的域名的SMTP服务器.现在可以在设置邮件提醒时选择是否自定义smtp服务器.

抱歉刚刚有设置弄错了,现在好了.