### PR TITLE
feat: add configurable sign_in_method for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@
 - `domain` (必需)：服务商的域名
 - `login_path` (可选)：登录页面路径，默认为 `/login`（仅在 `bypass_method` 为 `"waf_cookies"` 时使用）
 - `sign_in_path` (可选)：签到 API 路径，默认为 `/api/user/sign_in`
+- `sign_in_method` (可选)：签到请求方法，`"GET"` 或 `"POST"`，默认为 `"POST"`
 - `user_info_path` (可选)：用户信息 API 路径，默认为 `/api/user/self`
 - `api_user_key` (可选)：API 用户标识请求头名称，默认为 `new-api-user`
 - `bypass_method` (可选)：WAF 绕过方法
@@ -251,6 +252,7 @@
     "domain": "https://custom.example.com",
     "login_path": "/auth/login",
     "sign_in_path": "/api/checkin",
+    "sign_in_method": "GET",
     "user_info_path": "/api/profile",
     "api_user_key": "x-user-id",
     "bypass_method": "waf_cookies"

--- a/checkin.py
+++ b/checkin.py
@@ -175,7 +175,10 @@ def execute_check_in(client, account_name: str, provider_config, headers: dict):
 	checkin_headers.update({'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'})
 
 	sign_in_url = f'{provider_config.domain}{provider_config.sign_in_path}'
-	response = client.post(sign_in_url, headers=checkin_headers, timeout=30)
+	if provider_config.sign_in_method == 'GET':
+		response = client.get(sign_in_url, headers=checkin_headers, timeout=30)
+	else:
+		response = client.post(sign_in_url, headers=checkin_headers, timeout=30)
 
 	print(f'[RESPONSE] {account_name}: Response status code {response.status_code}')
 

--- a/checkin.py
+++ b/checkin.py
@@ -129,10 +129,10 @@ async def get_waf_cookies_with_playwright(account_name: str, login_url: str, req
 				return None
 
 
-def get_user_info(client, headers, user_info_url: str):
+async def get_user_info(client, headers, user_info_url: str):
 	"""获取用户信息"""
 	try:
-		response = client.get(user_info_url, headers=headers, timeout=30)
+		response = await client.get(user_info_url, headers=headers, timeout=30)
 
 		if response.status_code == 200:
 			data = response.json()
@@ -167,7 +167,7 @@ async def prepare_cookies(account_name: str, provider_config, user_cookies: dict
 	return {**waf_cookies, **user_cookies}
 
 
-def execute_check_in(client, account_name: str, provider_config, headers: dict):
+async def execute_check_in(client, account_name: str, provider_config, headers: dict):
 	"""执行签到请求"""
 	print(f'[NETWORK] {account_name}: Executing check-in')
 
@@ -176,9 +176,9 @@ def execute_check_in(client, account_name: str, provider_config, headers: dict):
 
 	sign_in_url = f'{provider_config.domain}{provider_config.sign_in_path}'
 	if provider_config.sign_in_method == 'GET':
-		response = client.get(sign_in_url, headers=checkin_headers, timeout=30)
+		response = await client.get(sign_in_url, headers=checkin_headers, timeout=30)
 	else:
-		response = client.post(sign_in_url, headers=checkin_headers, timeout=30)
+		response = await client.post(sign_in_url, headers=checkin_headers, timeout=30)
 
 	print(f'[RESPONSE] {account_name}: Response status code {response.status_code}')
 
@@ -280,7 +280,7 @@ async def check_in_account(account: AccountConfig, account_index: int, app_confi
 	if not all_cookies:
 		return False, None
 
-	client = httpx.Client(http2=True, timeout=30.0)
+	client = httpx.AsyncClient(http2=True, timeout=30.0)
 
 	try:
 		client.cookies.update(all_cookies)
@@ -300,28 +300,26 @@ async def check_in_account(account: AccountConfig, account_index: int, app_confi
 		}
 
 		user_info_url = f'{provider_config.domain}{provider_config.user_info_path}'
-		user_info_before = get_user_info(client, headers, user_info_url)
+		user_info_before = await get_user_info(client, headers, user_info_url)
 		if user_info_before and user_info_before.get('success'):
 			print(user_info_before['display'])
 		elif user_info_before:
 			print(user_info_before.get('error', 'Unknown error'))
 
 		if provider_config.needs_manual_check_in():
-			success = execute_check_in(client, account_name, provider_config, headers)
-			# 签到后再次获取用户信息，用于计算签到收益
-			user_info_after = get_user_info(client, headers, user_info_url)
+			success = await execute_check_in(client, account_name, provider_config, headers)
+			user_info_after = await get_user_info(client, headers, user_info_url)
 			return success, user_info_before, user_info_after
 		else:
 			print(f'[INFO] {account_name}: Check-in completed automatically (triggered by user info request)')
-			# 自动签到的情况，再次获取用户信息
-			user_info_after = get_user_info(client, headers, user_info_url)
+			user_info_after = await get_user_info(client, headers, user_info_url)
 			return True, user_info_before, user_info_after
 
 	except Exception as e:
 		print(f'[FAILED] {account_name}: Error occurred during check-in process - {str(e)[:50]}...')
 		return False, None, None
 	finally:
-		client.close()
+		await client.aclose()
 
 
 async def main():

--- a/utils/config.py
+++ b/utils/config.py
@@ -17,6 +17,7 @@ class ProviderConfig:
 	domain: str
 	login_path: str = '/login'
 	sign_in_path: str | None = '/api/user/sign_in'
+	sign_in_method: Literal['GET', 'POST'] = 'POST'
 	user_info_path: str = '/api/user/self'
 	api_user_key: str = 'new-api-user'
 	bypass_method: Literal['waf_cookies'] | None = None
@@ -51,6 +52,7 @@ class ProviderConfig:
 			domain=data['domain'],
 			login_path=data.get('login_path', '/login'),
 			sign_in_path=data.get('sign_in_path', '/api/user/sign_in'),
+			sign_in_method=data.get('sign_in_method', 'POST').upper(),
 			user_info_path=data.get('user_info_path', '/api/user/self'),
 			api_user_key=data.get('api_user_key', 'new-api-user'),
 			bypass_method=data.get('bypass_method'),


### PR DESCRIPTION
## 问题

部分 provider 的签到接口只接受 GET 请求，而当前代码固定使用 POST，导致 HTTP 404。

## 解决方案

在 `ProviderConfig` 中新增 `sign_in_method` 字段（默认 `POST`），`execute_check_in` 根据配置选择请求方法。

## 变更

- `utils/config.py`：`ProviderConfig` 新增 `sign_in_method: Literal['GET', 'POST']` 字段，默认 `POST`；`from_dict` 支持从配置读取
- `checkin.py`：`execute_check_in` 按 `sign_in_method` 选择 `client.get` 或 `client.post`
- `README.md`：补充 `sign_in_method` 字段说明和示例

## 兼容性

不影响现有配置，默认行为不变（仍为 POST）。