### PR TITLE
feat: 增加清理 GitHub Actions 历史运行记录的 workflow

### DIFF
--- a/.github/workflows/delete-workflow-runs.yml
+++ b/.github/workflows/delete-workflow-runs.yml
@@ -1,0 +1,72 @@
+name: 清理 Actions 历史记录
+
+on:
+  schedule:
+    # 每月 1 日 03:30 UTC 自动清理一次历史运行记录
+    - cron: '30 3 1 * *'
+  workflow_dispatch:
+    inputs:
+      retain_days:
+        description: '保留最近多少天的 workflow runs'
+        required: true
+        default: '30'
+      keep_minimum_runs:
+        description: '每个 workflow 至少保留多少条运行记录'
+        required: true
+        default: '6'
+      delete_workflow_pattern:
+        description: '按 workflow 名称或文件名过滤；留空表示全部，多个条件用 | 分隔'
+        required: false
+        default: ''
+      delete_workflow_by_state_pattern:
+        description: '按 workflow 状态过滤'
+        required: true
+        default: 'ALL'
+        type: choice
+        options:
+          - 'ALL'
+          - active
+          - deleted
+          - disabled_fork
+          - disabled_inactivity
+          - disabled_manually
+      delete_run_by_conclusion_pattern:
+        description: '按运行结果过滤'
+        required: true
+        default: 'ALL'
+        type: choice
+        options:
+          - 'ALL'
+          - action_required
+          - cancelled
+          - failure
+          - skipped
+          - success
+      dry_run:
+        description: '仅预览将删除的记录，不实际删除'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  delete-workflow-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 删除旧的 Actions 运行记录
+        uses: Mattraks/delete-workflow-runs@v2.1.0
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: ${{ github.event.inputs.retain_days || '30' }}
+          keep_minimum_runs: ${{ github.event.inputs.keep_minimum_runs || '6' }}
+          delete_workflow_pattern: ${{ github.event.inputs.delete_workflow_pattern || '' }}
+          delete_workflow_by_state_pattern: ${{ github.event.inputs.delete_workflow_by_state_pattern || 'ALL' }}
+          delete_run_by_conclusion_pattern: ${{ github.event.inputs.delete_run_by_conclusion_pattern || 'ALL' }}
+          dry_run: ${{ github.event.inputs.dry_run || 'false' }}

--- a/README.md
+++ b/README.md
@@ -127,6 +127,17 @@
 - 脚本每 6 小时执行一次（1. action 无法准确触发，基本延时 1~1.5h；2. 目前观测到 anyrouter 的签到是每 24h 而不是零点就可签到）
 - 你也可以随时手动触发签到
 
+## Actions 历史记录清理
+
+本项目已内置 `清理 Actions 历史记录` workflow，用于定期删除过旧的 GitHub Actions 运行记录，避免历史记录长期累积。
+
+- 默认每月 1 日 03:30 UTC 自动执行一次清理。
+- 默认保留最近 30 天的运行记录，并且每个 workflow 至少保留 6 条记录。
+- 支持在 GitHub Actions 页面手动运行，并可按 workflow 名称/文件名、workflow 状态、运行结果进行过滤。
+- 手动运行时可将 `dry_run` 设置为 `true`，先预览将被删除的记录，不实际删除。
+
+该功能使用 [Mattraks/delete-workflow-runs](https://github.com/marketplace/actions/delete-workflow-runs)，并通过仓库默认的 `GITHUB_TOKEN` 授予 `actions: write` 与 `contents: read` 权限来删除当前仓库的历史运行记录。
+
 ## 注意事项
 
 - 请确保每个账号的 cookies 和 API User 都是正确的


### PR DESCRIPTION
## 📋 PR 描述

新增 GitHub Actions 历史记录清理 workflow：支持每月自动清理、手动触发、保留天数/最少保留数量/过滤条件/dry_run 参数，并授予 actions: write 与 contents: read 权限。

### 🎯 改动类型

<!-- 请勾选适用的选项，只选择最主要的一个 -->
- [✅] ✨ 新功能（添加新的功能特性）
