### PR TITLE
Add GitHub OAuth/TOTP check-in workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@
 
 ANYROUTER_ACCOUNTS=[{"email":"your@email.com","password":"your_password","api_user":"你的api_user值"}]
 
+# GitHub OAuth/TOTP 登录（可选，对应 checkin_github_oauth.py 与 GitHub OAuth Actions）
+# 建议在 GitHub Environment Secret 中配置 ANYROUTER_GITHUB_ACCOUNTS，不要提交真实账号或 TOTP。
+# ANYROUTER_GITHUB_ACCOUNTS=[{"name":"github-main","github_username":"your_github_email@example.com","github_password":"your_github_password","totp_secret":"BASE32TOTPSECRET"}]
+# 如 GitHub 临时要求邮箱设备验证码，可手动触发 workflow 并临时配置：
+# ANYROUTER_GITHUB_DEVICE_CODES={"github-main":"123456"}
+
 # 调试模式：true 时保存登录截图、输出代理地址/api_user 等详细日志（默认 false）
 # DEBUG_MODE=false
 # CHECKIN_BROWSER_PROFILE_DIR=.browser_profiles

--- a/.github/workflows/github-oauth-checkin.yml
+++ b/.github/workflows/github-oauth-checkin.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   github-oauth-checkin:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     environment: production
     env:
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/github-oauth-checkin.yml
+++ b/.github/workflows/github-oauth-checkin.yml
@@ -1,0 +1,149 @@
+name: AnyRouter GitHub OAuth 自动签到
+
+on:
+  schedule:
+    # Runs daily at 10:17 Asia/Shanghai, then script adds random jitter.
+    - cron: '17 2 * * *'
+  workflow_dispatch:
+    inputs:
+      account_only:
+        description: 只运行指定账号 name 或 GitHub 邮箱，多个用英文逗号分隔
+        required: false
+        default: ''
+        type: string
+      no_delay:
+        description: 跳过随机延迟
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  github-oauth-checkin:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: production
+    env:
+      PYTHONIOENCODING: utf-8
+      PYTHONUNBUFFERED: 1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          version: latest
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: 缓存 UV 依赖
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: 安装依赖
+        run: uv sync --frozen
+
+      - name: 安装 Playwright Chromium
+        run: uv run python -m playwright install --with-deps chromium
+
+      - name: 恢复 GitHub OAuth 登录态
+        uses: actions/cache/restore@v4
+        with:
+          path: storage-states
+          key: anyrouter-github-oauth-storage-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            anyrouter-github-oauth-storage-${{ runner.os }}-
+
+      - name: 执行 GitHub OAuth 签到
+        id: run-checkin
+        env:
+          ANYROUTER_GITHUB_ACCOUNTS: ${{ secrets.ANYROUTER_GITHUB_ACCOUNTS }}
+          ANYROUTER_GITHUB_DEVICE_CODES: ${{ secrets.ANYROUTER_GITHUB_DEVICE_CODES }}
+          CHECKIN_HEADLESS: true
+          ACCOUNT_ONLY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.account_only || '' }}
+          NO_DELAY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.no_delay == 'true' && 'true' || 'false' }}
+        run: |
+          set -o pipefail
+          args=()
+          if [ "$NO_DELAY" = "true" ]; then
+            args+=(--no-delay)
+          fi
+          uv run python -u checkin_github_oauth.py "${args[@]}" 2>&1 | tee github-oauth-checkin.log
+
+      - name: 失败通知
+        if: always() && steps.run-checkin.outcome != 'success'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DINGDING_WEBHOOK: ${{ secrets.DINGDING_WEBHOOK }}
+          EMAIL_USER: ${{ secrets.EMAIL_USER }}
+          EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
+          EMAIL_TO: ${{ secrets.EMAIL_TO }}
+          EMAIL_SENDER: ${{ secrets.EMAIL_SENDER }}
+          CUSTOM_SMTP_SERVER: ${{ secrets.CUSTOM_SMTP_SERVER }}
+          PUSHPLUS_TOKEN: ${{ secrets.PUSHPLUS_TOKEN }}
+          SERVERPUSHKEY: ${{ secrets.SERVERPUSHKEY }}
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_WEBHOOK }}
+          FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+          FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+          FEISHU_RECEIVE_ID: ${{ secrets.FEISHU_RECEIVE_ID }}
+          FEISHU_RECEIVE_ID_TYPE: ${{ secrets.FEISHU_RECEIVE_ID_TYPE }}
+          WEIXIN_WEBHOOK: ${{ secrets.WEIXIN_WEBHOOK }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          GOTIFY_URL: ${{ secrets.GOTIFY_URL }}
+          GOTIFY_TOKEN: ${{ secrets.GOTIFY_TOKEN }}
+          GOTIFY_PRIORITY: ${{ secrets.GOTIFY_PRIORITY }}
+          BARK_KEY: ${{ secrets.BARK_KEY }}
+          BARK_SERVER: ${{ secrets.BARK_SERVER }}
+        run: |
+          uv run python - <<'PY'
+          import os
+          from pathlib import Path
+
+          from utils.notify import notify
+
+          configured = [
+              'DINGDING_WEBHOOK',
+              'EMAIL_USER',
+              'PUSHPLUS_TOKEN',
+              'SERVERPUSHKEY',
+              'FEISHU_WEBHOOK',
+              'FEISHU_APP_ID',
+              'WEIXIN_WEBHOOK',
+              'TELEGRAM_BOT_TOKEN',
+              'GOTIFY_URL',
+              'BARK_KEY',
+          ]
+          if not any(os.getenv(name) for name in configured):
+              print('No notification secret configured; failure notification skipped.')
+              raise SystemExit(0)
+
+          log_path = Path('github-oauth-checkin.log')
+          log_tail = ''
+          if log_path.exists():
+              log_tail = '\n'.join(log_path.read_text(encoding='utf-8', errors='replace').splitlines()[-80:])
+
+          content = f'Run: {os.getenv("RUN_URL", "")}\n\n{log_tail}'
+          notify.push_message('AnyRouter GitHub OAuth 签到失败', content)
+          PY
+
+      - name: 保存 GitHub OAuth 登录态
+        if: always() && hashFiles('storage-states/*.json') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: storage-states
+          key: anyrouter-github-oauth-storage-${{ runner.os }}-${{ github.run_id }}
+
+      - name: 上传 OAuth 日志
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-oauth-checkin-${{ github.run_id }}
+          path: github-oauth-checkin.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/github-oauth-checkin.yml
+++ b/.github/workflows/github-oauth-checkin.yml
@@ -1,9 +1,6 @@
 name: AnyRouter GitHub OAuth 自动签到
 
 on:
-  schedule:
-    # Runs daily at 10:17 Asia/Shanghai, then script adds random jitter.
-    - cron: '17 2 * * *'
   workflow_dispatch:
     inputs:
       account_only:

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ htmlcov
 balance_hash.txt
 .browser_profiles
 checkin_screenshots
+accounts.json
+storage-states
+github-oauth-checkin.log
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -86,6 +86,41 @@
 - `provider` (可选)：指定使用的服务商，默认为 `anyrouter`
 - `name` (可选)：自定义账号显示名称，用于通知和日志中标识账号
 
+### GitHub OAuth/TOTP 模式（可选）
+
+如果账号已经绑定 AnyRouter 的 GitHub 登录，也可以使用 `checkin_github_oauth.py` 与 `AnyRouter GitHub OAuth 自动签到` workflow。该模式通过浏览器完成 GitHub OAuth，然后在浏览器上下文中调用 AnyRouter 签到接口，适合被 WAF 拦截的环境。
+
+该实现参考了 [liukaizheng/anyrouter-check-in](https://github.com/liukaizheng/anyrouter-check-in) 的 GitHub OAuth 浏览器流程，并针对本仓库的 Python/Playwright 与 GitHub Actions 运行方式做了适配。
+
+在仓库 `Settings -> Environments -> production -> Environment secrets` 中添加：
+
+- `ANYROUTER_GITHUB_ACCOUNTS`：GitHub OAuth 账号配置（JSON 数组）
+- `ANYROUTER_GITHUB_DEVICE_CODES`：可选，仅当 GitHub 临时要求邮箱设备验证码时使用
+
+`ANYROUTER_GITHUB_ACCOUNTS` 示例：
+
+```json
+[
+  {
+    "name": "github-main",
+    "github_username": "your_github_email@example.com",
+    "github_password": "your_github_password",
+    "totp_secret": "BASE32TOTPSECRET"
+  }
+]
+```
+
+`ANYROUTER_GITHUB_DEVICE_CODES` 示例：
+
+```json
+{
+  "github-main": "123456",
+  "your_github_email@example.com": "123456"
+}
+```
+
+通常启用 GitHub TOTP 后无需 `GITHUB_DEVICE_CODES`。如果 GitHub 因新设备或新 IP 额外要求邮箱验证码，可以手动触发 workflow，临时配置该 secret 让脚本保存 GitHub 登录态。
+
 **默认值说明**：
 
 - 如果未提供 `provider` 字段，默认使用 `anyrouter`（向后兼容）

--- a/README.md
+++ b/README.md
@@ -15,12 +15,28 @@
 
 用于 Claude Code 中转站 Any Router 网站多账号每日签到，一次 $25，限时注册即送 100 美金，[点击这里注册](https://anyrouter.top/register?aff=gSsN)。业界良心，支持 Claude Sonnet 4.5、GPT-5-Codex、Claude Code 百万上下文（使用 `/model sonnet[1m]` 开启），`gemini-2.5-pro` 模型。
 
+## 本 fork 说明
+
+本仓库 fork 自 [millylee/anyrouter-check-in](https://github.com/millylee/anyrouter-check-in)，保留了上游的多 Provider、Cookie/邮箱密码登录、CloakBrowser WAF 绕过、通知与测试体系。
+
+在此基础上，本 fork 额外加入了 AnyRouter GitHub OAuth/TOTP 签到路径：
+
+- 新增 `checkin_github_oauth.py`，使用 Python + Playwright Chromium 完成 GitHub OAuth 登录与 AnyRouter 签到。
+- 新增 `AnyRouter GitHub OAuth 自动签到` GitHub Actions workflow，读取 `ANYROUTER_GITHUB_ACCOUNTS` secret，支持 TOTP、登录态缓存、手动指定账号运行。
+- GitHub OAuth 流程参考了 [liukaizheng/anyrouter-check-in](https://github.com/liukaizheng/anyrouter-check-in)，但实现方式不同：本 fork 是 Python/Playwright + GitHub Actions 适配；同时处理 AnyRouter WAF、OAuth code 被前端提前消费、只保存 GitHub 登录态、失败通知等运行细节。
+- 与上游 fork 的主要差异是新增 GitHub OAuth/TOTP 路线；原有 Cookie/邮箱密码路线仍保留。
+
+目前差异仍属于“在上游基础上的可选增强”，还没大到必须脱离 fork。如果后续决定删除上游的通用 Provider/CloakBrowser 逻辑，只保留 GitHub OAuth/TOTP 专用签到器，再考虑新建独立仓库会更合适。
+
+运行上建议只选择一个自动调度入口：服务器 cron 或 GitHub Actions 定时二选一。两边都跑虽然可行，但同一批 GitHub 账号每天从两个环境登录/OAuth，会增加不必要的风控面；另一个入口保留为手动备份即可。
+
 ## 功能特性
 
 - ✅ 多平台（兼容 NewAPI 与 OneAPI）
 - ✅ 单个/多账号自动签到
 - ✅ 多种机器人通知（可选）
 - ✅ 绕过 WAF 限制
+- ✅ GitHub OAuth + TOTP 签到模式（本 fork 新增）
 
 ## 使用方法
 
@@ -119,7 +135,7 @@
 }
 ```
 
-通常启用 GitHub TOTP 后无需 `GITHUB_DEVICE_CODES`。如果 GitHub 因新设备或新 IP 额外要求邮箱验证码，可以手动触发 workflow，临时配置该 secret 让脚本保存 GitHub 登录态。
+通常启用 GitHub TOTP 后无需 `ANYROUTER_GITHUB_DEVICE_CODES`。如果 GitHub 因新设备或新 IP 额外要求邮箱验证码，可以手动触发 workflow，临时配置该 secret 让脚本保存 GitHub 登录态。
 
 **默认值说明**：
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,19 @@
 
 用于 Claude Code 中转站 Any Router 网站多账号每日签到，一次 $25，限时注册即送 100 美金，[点击这里注册](https://anyrouter.top/register?aff=gSsN)。业界良心，支持 Claude Sonnet 4.5、GPT-5-Codex、Claude Code 百万上下文（使用 `/model sonnet[1m]` 开启），`gemini-2.5-pro` 模型。
 
-## 本 fork 说明
+## GitHub OAuth 扩展说明
 
-本仓库 fork 自 [millylee/anyrouter-check-in](https://github.com/millylee/anyrouter-check-in)，保留了上游的多 Provider、Cookie/邮箱密码登录、CloakBrowser WAF 绕过、通知与测试体系。
+当前代码基于 [millylee/anyrouter-check-in](https://github.com/millylee/anyrouter-check-in)，保留了上游的多 Provider、Cookie/邮箱密码登录、CloakBrowser WAF 绕过、通知与测试体系。
 
-在此基础上，本 fork 额外加入了 AnyRouter GitHub OAuth/TOTP 签到路径：
+在此基础上，额外加入了 AnyRouter GitHub OAuth/TOTP 签到路径：
 
 - 新增 `checkin_github_oauth.py`，使用 Python + Playwright Chromium 完成 GitHub OAuth 登录与 AnyRouter 签到。
 - 新增 `AnyRouter GitHub OAuth 自动签到` GitHub Actions workflow，读取 `ANYROUTER_GITHUB_ACCOUNTS` secret，支持 TOTP、登录态缓存、手动指定账号运行。
-- GitHub OAuth 流程参考了 [liukaizheng/anyrouter-check-in](https://github.com/liukaizheng/anyrouter-check-in)，但实现方式不同：本 fork 是 Python/Playwright + GitHub Actions 适配；同时处理 AnyRouter WAF、OAuth code 被前端提前消费、只保存 GitHub 登录态、失败通知等运行细节。
-- 与上游 fork 的主要差异是新增 GitHub OAuth/TOTP 路线；原有 Cookie/邮箱密码路线仍保留。
+- GitHub OAuth/TOTP 流程参考了 [liukaizheng/anyrouter-check-in](https://github.com/liukaizheng/anyrouter-check-in)，尤其是其 README 中的 [GitHub OAuth Session Acquisition 流程示意](https://github.com/liukaizheng/anyrouter-check-in#github-oauth-session-acquisition-detailed) 与 TOTP 处理说明。
+- 与参考项目的实现差异：参考项目使用 Rust/chromiumoxide；这里使用 Python/Playwright，并适配本仓库已有的依赖、通知和 GitHub Actions 结构。
+- 与上游项目的主要差异：新增 GitHub OAuth/TOTP 路线；原有 Cookie/邮箱密码路线仍保留。
 
-目前差异仍属于“在上游基础上的可选增强”，还没大到必须脱离 fork。如果后续决定删除上游的通用 Provider/CloakBrowser 逻辑，只保留 GitHub OAuth/TOTP 专用签到器，再考虑新建独立仓库会更合适。
+如果只需要 GitHub OAuth/TOTP 专用签到器，也可以直接参考上面的 Rust 实现；如果需要兼容上游已有的多 Provider 和通知能力，可以使用这里的 Python/Playwright 扩展路径。
 
 运行上建议只选择一个自动调度入口：服务器 cron 或 GitHub Actions 定时二选一。两边都跑虽然可行，但同一批 GitHub 账号每天从两个环境登录/OAuth，会增加不必要的风控面；另一个入口保留为手动备份即可。
 
@@ -36,7 +37,7 @@
 - ✅ 单个/多账号自动签到
 - ✅ 多种机器人通知（可选）
 - ✅ 绕过 WAF 限制
-- ✅ GitHub OAuth + TOTP 签到模式（本 fork 新增）
+- ✅ GitHub OAuth + TOTP 签到模式
 
 ## 使用方法
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 如果只需要 GitHub OAuth/TOTP 专用签到器，也可以直接参考上面的 Rust 实现；如果需要兼容上游已有的多 Provider 和通知能力，可以使用这里的 Python/Playwright 扩展路径。
 
-运行上建议只选择一个自动调度入口：服务器 cron 或 GitHub Actions 定时二选一。两边都跑虽然可行，但同一批 GitHub 账号每天从两个环境登录/OAuth，会增加不必要的风控面；另一个入口保留为手动备份即可。
+为避免影响上游默认定时任务，新增的 GitHub OAuth workflow 默认只支持 `workflow_dispatch` 手动触发，不会替代或干扰原有 `AnyRouter 自动签到` workflow。确认 `ANYROUTER_GITHUB_ACCOUNTS` 配置可用后，如需定时执行，可以自行给该 workflow 增加 `schedule`。
 
 ## 功能特性
 
@@ -137,6 +137,8 @@
 ```
 
 通常启用 GitHub TOTP 后无需 `ANYROUTER_GITHUB_DEVICE_CODES`。如果 GitHub 因新设备或新 IP 额外要求邮箱验证码，可以手动触发 workflow，临时配置该 secret 让脚本保存 GitHub 登录态。
+
+该 workflow 默认只手动运行，不会改变原有 `AnyRouter 自动签到` workflow 的定时行为；需要 GitHub OAuth 定时任务时，可在 `.github/workflows/github-oauth-checkin.yml` 中按需增加 `schedule`。
 
 **默认值说明**：
 

--- a/checkin_github_oauth.py
+++ b/checkin_github_oauth.py
@@ -14,12 +14,15 @@ import json
 import os
 import random
 import re
+import secrets
 import sys
 import time
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from dotenv import load_dotenv
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 from playwright.async_api import async_playwright
 
 load_dotenv()
@@ -111,35 +114,37 @@ def generate_totp(secret: str) -> str:
 
 
 def github_device_code(account: dict) -> str:
-	single = (os.getenv('ANYROUTER_GITHUB_DEVICE_CODE') or os.getenv('GITHUB_DEVICE_CODE', '')).strip()
+	single = (os.getenv('ANYROUTER_GITHUB_DEVICE_CODE') or os.getenv('GITHUB_DEVICE_CODE') or '').strip()
 	if single:
 		return single
 
-	raw = (os.getenv('ANYROUTER_GITHUB_DEVICE_CODES') or os.getenv('GITHUB_DEVICE_CODES', '')).strip()
+	raw = (os.getenv('ANYROUTER_GITHUB_DEVICE_CODES') or os.getenv('GITHUB_DEVICE_CODES') or '').strip()
 	if not raw:
 		return ''
 
+	mapping: dict[str, Any]
 	try:
-		mapping = json.loads(raw)
+		raw_mapping = json.loads(raw)
+		mapping = raw_mapping if isinstance(raw_mapping, dict) else {}
 	except Exception:
 		mapping = {}
 		for item in raw.split(','):
 			if '=' in item:
-				key, value = item.split('=', 1)
+				item_key, value = item.split('=', 1)
 			elif ':' in item:
-				key, value = item.split(':', 1)
+				item_key, value = item.split(':', 1)
 			else:
 				continue
-			mapping[key.strip()] = value.strip()
+			mapping[item_key.strip()] = value.strip()
 
-	for key in (account.get('name'), account.get('github_username')):
-		if key and str(mapping.get(key, '')).strip():
-			return str(mapping[key]).strip()
+	for lookup_key in (str(account.get('name') or ''), str(account.get('github_username') or '')):
+		if lookup_key and str(mapping.get(lookup_key, '')).strip():
+			return str(mapping[lookup_key]).strip()
 	return ''
 
 
 async def safe_click_authorize(page) -> str:
-	return await page.evaluate(
+	result = await page.evaluate(
 		"""() => {
 			const blocked = /cancel|deny|decline|return|back|取消|拒绝|返回/i;
 			const allowed = /authorize|authorise|allow|approve|授权|允许|同意/i;
@@ -176,6 +181,7 @@ async def safe_click_authorize(page) -> str:
 			return '';
 		}"""
 	)
+	return str(result or '')
 
 
 async def switch_to_totp(page) -> None:
@@ -196,14 +202,15 @@ async def switch_to_totp(page) -> None:
 
 
 async def page_summary(page) -> str:
-	return await page.evaluate(
+	result = await page.evaluate(
 		"""() => document.body.innerText
 			.split("\\n")
 			.map((line) => line.trim())
 			.filter(Boolean)
 			.slice(0, 8)
-			.join(" | ")"""
+				.join(" | ")"""
 	)
+	return str(result or '')
 
 
 async def fill_totp_if_needed(page, account: dict) -> None:
@@ -261,16 +268,16 @@ async def fill_totp_if_needed(page, account: dict) -> None:
 	await field.fill(code)
 	try:
 		await page.wait_for_url(lambda url: url != old_url, timeout=15000)
-	except Exception:
-		pass
+	except PlaywrightTimeoutError:
+		print('  - verification submit did not navigate before timeout')
 	await page.wait_for_timeout(3000)
 
 
 async def wait_for_settle(page, timeout: int = 10000) -> None:
 	try:
 		await page.wait_for_load_state('domcontentloaded', timeout=timeout)
-	except Exception:
-		pass
+	except PlaywrightTimeoutError:
+		print(f'  - page did not reach domcontentloaded within {timeout}ms')
 	await page.wait_for_timeout(1000)
 
 
@@ -280,10 +287,10 @@ async def goto_document(page, url: str):
 	return response
 
 
-async def browser_json(page, path: str, method: str = 'GET', headers: dict | None = None) -> dict:
-	last = None
+async def browser_json(page, path: str, method: str = 'GET', headers: dict | None = None) -> dict[str, Any]:
+	last: dict[str, Any] | None = None
 	for _ in range(8):
-		result = await page.evaluate(
+		raw_result = await page.evaluate(
 			"""async ({path, method, headers}) => {
 				const response = await fetch(path, {
 					method,
@@ -304,6 +311,12 @@ async def browser_json(page, path: str, method: str = 'GET', headers: dict | Non
 			}""",
 			{'path': path, 'method': method, 'headers': headers or {}},
 		)
+		if not isinstance(raw_result, dict):
+			last = {'status': 'unknown', 'contentType': 'unknown', 'sample': str(raw_result)[:160]}
+			await page.wait_for_timeout(3000)
+			continue
+
+		result: dict[str, Any] = raw_result
 		last = result
 		if result.get('data') is not None:
 			return result
@@ -509,14 +522,16 @@ async def main() -> int:
 	failed = 0
 
 	if not no_delay and START_DELAY_MAX_SECONDS > 0:
-		start_delay = random.randint(0, START_DELAY_MAX_SECONDS)
+		start_delay = secrets.randbelow(START_DELAY_MAX_SECONDS + 1)
 		print(f'startup random delay: {start_delay}s')
 		await asyncio.sleep(start_delay)
 
 	async with async_playwright() as playwright:
 		for index, account in enumerate(accounts[:limit]):
 			if index > 0 and not no_delay:
-				delay = random.randint(ACCOUNT_DELAY_MIN_SECONDS, ACCOUNT_DELAY_MAX_SECONDS)
+				delay = ACCOUNT_DELAY_MIN_SECONDS + secrets.randbelow(
+					ACCOUNT_DELAY_MAX_SECONDS - ACCOUNT_DELAY_MIN_SECONDS + 1
+				)
 				print(f'delay before next account: {delay}s')
 				await asyncio.sleep(delay)
 			ok = await check_account(playwright, account, index)

--- a/checkin_github_oauth.py
+++ b/checkin_github_oauth.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""
+AnyRouter GitHub OAuth check-in.
+
+This workflow is adapted for this repository and references the browser OAuth
+approach from https://github.com/liukaizheng/anyrouter-check-in.
+"""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+import random
+import re
+import sys
+import time
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from dotenv import load_dotenv
+from playwright.async_api import async_playwright
+
+load_dotenv()
+
+ROOT = Path(__file__).resolve().parent
+ACCOUNTS_FILE = ROOT / 'accounts.json'
+STORAGE_DIR = ROOT / 'storage-states'
+PROVIDER_ORIGIN = os.getenv('ANYROUTER_ORIGIN', 'https://anyrouter.top').rstrip('/')
+START_DELAY_MAX_SECONDS = int(os.getenv('START_DELAY_MAX_SECONDS', '1800'))
+ACCOUNT_DELAY_MIN_SECONDS = int(os.getenv('ACCOUNT_DELAY_MIN_SECONDS', '120'))
+ACCOUNT_DELAY_MAX_SECONDS = int(os.getenv('ACCOUNT_DELAY_MAX_SECONDS', '480'))
+
+
+def mask_username(username: str) -> str:
+	if '@' in username:
+		head, tail = username.split('@', 1)
+		return f'{head[:2]}***@{tail}'
+	return f'{username[:2]}***'
+
+
+def scrub_url(url: str) -> str:
+	return re.sub(r'([?&](?:code|state|client_id)=)[^&]+', r'\1[redacted]', url)
+
+
+def provider_host() -> str:
+	return urlparse(PROVIDER_ORIGIN).netloc
+
+
+def oauth_query(url: str) -> dict | None:
+	parsed = urlparse(url)
+	if not parsed.netloc.endswith(provider_host()):
+		return None
+	query = parse_qs(parsed.query)
+	if 'code' in query and 'state' in query:
+		return query
+	return None
+
+
+def github_only_storage_state(state: dict) -> dict:
+	return {
+		'cookies': [cookie for cookie in state.get('cookies', []) if 'github.com' in cookie.get('domain', '')],
+		'origins': [origin for origin in state.get('origins', []) if 'github.com' in origin.get('origin', '')],
+	}
+
+
+def load_github_storage_state(path: Path) -> dict:
+	return github_only_storage_state(json.loads(path.read_text(encoding='utf-8')))
+
+
+def load_accounts() -> list[dict]:
+	raw = os.getenv('ANYROUTER_GITHUB_ACCOUNTS', '').strip()
+	if raw:
+		accounts = json.loads(raw)
+	elif ACCOUNTS_FILE.exists():
+		accounts = json.loads(ACCOUNTS_FILE.read_text(encoding='utf-8'))
+	else:
+		raise RuntimeError('ANYROUTER_GITHUB_ACCOUNTS is not configured and accounts.json was not found')
+
+	if not isinstance(accounts, list) or not accounts:
+		raise RuntimeError('ANYROUTER_GITHUB_ACCOUNTS must be a non-empty JSON array')
+
+	for index, account in enumerate(accounts):
+		if not isinstance(account, dict):
+			raise RuntimeError(f'account #{index + 1} must be an object')
+		account.setdefault('name', f'account-{index + 1}')
+		if 'github_username' not in account and 'username' in account:
+			account['github_username'] = account['username']
+		if 'github_password' not in account and 'password' in account:
+			account['github_password'] = account['password']
+		if 'totp_secret' not in account and 'totp' in account:
+			account['totp_secret'] = account['totp']
+		if not account.get('github_username') or not account.get('github_password'):
+			raise RuntimeError(f'{account["name"]}: github_username and github_password are required')
+
+	return accounts
+
+
+def generate_totp(secret: str) -> str:
+	clean = (secret or '').strip().replace(' ', '').upper()
+	if not clean:
+		return ''
+	clean += '=' * ((8 - len(clean) % 8) % 8)
+	key = base64.b32decode(clean)
+	counter = int(time.time() // 30).to_bytes(8, 'big')
+	digest = hmac.new(key, counter, hashlib.sha1).digest()
+	offset = digest[-1] & 0x0F
+	code = int.from_bytes(digest[offset : offset + 4], 'big') & 0x7FFFFFFF
+	return f'{code % 1_000_000:06d}'
+
+
+def github_device_code(account: dict) -> str:
+	single = (os.getenv('ANYROUTER_GITHUB_DEVICE_CODE') or os.getenv('GITHUB_DEVICE_CODE', '')).strip()
+	if single:
+		return single
+
+	raw = (os.getenv('ANYROUTER_GITHUB_DEVICE_CODES') or os.getenv('GITHUB_DEVICE_CODES', '')).strip()
+	if not raw:
+		return ''
+
+	try:
+		mapping = json.loads(raw)
+	except Exception:
+		mapping = {}
+		for item in raw.split(','):
+			if '=' in item:
+				key, value = item.split('=', 1)
+			elif ':' in item:
+				key, value = item.split(':', 1)
+			else:
+				continue
+			mapping[key.strip()] = value.strip()
+
+	for key in (account.get('name'), account.get('github_username')):
+		if key and str(mapping.get(key, '')).strip():
+			return str(mapping[key]).strip()
+	return ''
+
+
+async def safe_click_authorize(page) -> str:
+	return await page.evaluate(
+		"""() => {
+			const blocked = /cancel|deny|decline|return|back|取消|拒绝|返回/i;
+			const allowed = /authorize|authorise|allow|approve|授权|允许|同意/i;
+			const visible = (el) => {
+				if (!el || !el.isConnected) return false;
+				const style = window.getComputedStyle(el);
+				if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) return false;
+				const rect = el.getBoundingClientRect();
+				return rect.width > 0 && rect.height > 0;
+			};
+			for (const selector of [
+				'button[name="authorize"][value="1"]',
+				'input[name="authorize"][value="1"]',
+				'#js-oauth-authorize-btn'
+			]) {
+				const el = document.querySelector(selector);
+				if (visible(el) && !el.disabled) {
+					const label = `${el.innerText || ''} ${el.value || ''}`.trim();
+					if (!blocked.test(label)) {
+						el.click();
+						return selector;
+					}
+				}
+			}
+			for (const el of document.querySelectorAll('button, input[type="submit"], input[type="button"]')) {
+				if (!visible(el) || el.disabled) continue;
+				const label = `${el.innerText || ''} ${el.value || ''} ${el.name || ''}`.trim();
+				if (blocked.test(label)) continue;
+				if (allowed.test(label) || (el.name === 'authorize' && el.value === '1')) {
+					el.click();
+					return label || el.id || el.name || 'authorize';
+				}
+			}
+			return '';
+		}"""
+	)
+
+
+async def switch_to_totp(page) -> None:
+	await page.evaluate(
+		"""() => {
+			const keywords = /authenticator|totp|another way|other method|verification code|use your|authentication app|另一种方式|验证码/i;
+			for (const el of document.querySelectorAll('a, button')) {
+				const text = (el.textContent || '').trim();
+				if (keywords.test(text)) {
+					el.click();
+					return true;
+				}
+			}
+			return false;
+		}"""
+	)
+	await page.wait_for_timeout(1500)
+
+
+async def page_summary(page) -> str:
+	return await page.evaluate(
+		"""() => document.body.innerText
+			.split("\\n")
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.slice(0, 8)
+			.join(" | ")"""
+	)
+
+
+async def fill_totp_if_needed(page, account: dict) -> None:
+	totp_selectors = [
+		'#app_totp',
+		'#totp',
+		'input[name="app_totp"]',
+		'input[name="totp"]',
+	]
+	generic_code_selectors = [
+		'input[name="otp"]',
+		'input[autocomplete="one-time-code"]',
+		'input[type="text"][inputmode="numeric"]',
+		'input[type="number"]',
+		'input[inputmode="numeric"]',
+	]
+
+	field = None
+	for selector in totp_selectors:
+		field = await page.query_selector(selector)
+		if field:
+			break
+
+	if not field and ('two-factor' in page.url or '2fa' in page.url):
+		await switch_to_totp(page)
+		for selector in totp_selectors + generic_code_selectors:
+			field = await page.query_selector(selector)
+			if field:
+				break
+
+	if not field:
+		for selector in generic_code_selectors:
+			field = await page.query_selector(selector)
+			if field:
+				break
+
+	if not field:
+		return
+
+	detail = await page_summary(page)
+	is_device_verification = 'sessions/verified-device' in page.url or 'Device verification' in detail
+
+	if is_device_verification:
+		code = github_device_code(account)
+		if not code:
+			raise RuntimeError(f'GitHub device verification code is required at {scrub_url(page.url)}: {detail[:300]}')
+		print(f'  - filled GitHub device verification code for {mask_username(account["github_username"])}')
+	else:
+		code = generate_totp(account.get('totp_secret', ''))
+		if not code:
+			raise RuntimeError(f'GitHub TOTP is required at {scrub_url(page.url)}: {detail[:300]}')
+		print(f'  - generated TOTP for {mask_username(account["github_username"])}')
+
+	old_url = page.url
+	await field.fill(code)
+	try:
+		await page.wait_for_url(lambda url: url != old_url, timeout=15000)
+	except Exception:
+		pass
+	await page.wait_for_timeout(3000)
+
+
+async def wait_for_settle(page, timeout: int = 10000) -> None:
+	try:
+		await page.wait_for_load_state('domcontentloaded', timeout=timeout)
+	except Exception:
+		pass
+	await page.wait_for_timeout(1000)
+
+
+async def goto_document(page, url: str):
+	response = await page.goto(url, wait_until='commit', timeout=45000)
+	await wait_for_settle(page)
+	return response
+
+
+async def browser_json(page, path: str, method: str = 'GET', headers: dict | None = None) -> dict:
+	last = None
+	for _ in range(8):
+		result = await page.evaluate(
+			"""async ({path, method, headers}) => {
+				const response = await fetch(path, {
+					method,
+					headers: headers || {},
+					credentials: "same-origin"
+				});
+				const text = await response.text();
+				let data = null;
+				try {
+					data = JSON.parse(text);
+				} catch (_) {}
+				return {
+					status: response.status,
+					contentType: response.headers.get("content-type") || "",
+					data,
+					sample: text.slice(0, 160)
+				};
+			}""",
+			{'path': path, 'method': method, 'headers': headers or {}},
+		)
+		last = result
+		if result.get('data') is not None:
+			return result
+		await page.wait_for_timeout(3000)
+
+	raise RuntimeError(
+		f'{scrub_url(path)} did not return JSON: status={last.get("status") if last else "unknown"} '
+		f'type={last.get("contentType") if last else "unknown"} sample={last.get("sample") if last else ""!r}'
+	)
+
+
+async def get_oauth_data(page) -> dict:
+	await goto_document(page, f'{PROVIDER_ORIGIN}/login')
+	await page.wait_for_timeout(6000)
+	status = await browser_json(page, '/api/status')
+	state = await browser_json(page, '/api/oauth/state')
+	return {'client_id': status['data']['data']['github_client_id'], 'state': state['data']['data']}
+
+
+async def check_account(playwright, account: dict, index: int) -> bool:
+	name = account.get('name') or f'account-{index + 1}'
+	username = account['github_username']
+	password = account['github_password']
+	STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+	state_path = STORAGE_DIR / f'github_{hashlib.sha256(username.encode()).hexdigest()[:12]}.json'
+
+	print(f'[{name}] start GitHub OAuth ({mask_username(username)})')
+
+	launch = {
+		'headless': os.getenv('CHECKIN_HEADLESS', 'true').lower() in {'1', 'true', 'yes', 'on'},
+		'args': [
+			'--no-sandbox',
+			'--disable-setuid-sandbox',
+			'--ignore-certificate-errors',
+			'--disable-blink-features=AutomationControlled',
+		],
+	}
+	browser = await playwright.chromium.launch(**launch)
+	context_kwargs = {'ignore_https_errors': True, 'locale': 'zh-CN', 'viewport': {'width': 1920, 'height': 1080}}
+	if state_path.exists():
+		context_kwargs['storage_state'] = load_github_storage_state(state_path)
+		print(f'[{name}] restored GitHub storage state')
+
+	context = await browser.new_context(**context_kwargs)
+	page = await context.new_page()
+	callback_urls: list[str] = []
+
+	async def capture_oauth_callback(route):
+		url = route.request.url
+		if oauth_query(url):
+			callback_urls.append(url)
+			print(f'[{name}] captured OAuth callback: {scrub_url(url)}')
+			if route.request.resource_type in {'fetch', 'xhr'}:
+				await route.fulfill(
+					status=200,
+					content_type='application/json; charset=utf-8',
+					body='{"success":false,"message":"OAuth callback captured by check-in script"}',
+				)
+				return
+			await route.fulfill(
+				status=200,
+				content_type='text/html; charset=utf-8',
+				body='<html><body>OAuth callback captured.</body></html>',
+			)
+			return
+		await route.continue_()
+
+	def remember_url(url: str) -> None:
+		if oauth_query(url):
+			callback_urls.append(url)
+
+	page.on('request', lambda request: remember_url(request.url))
+	page.on('framenavigated', lambda frame: remember_url(frame.url))
+
+	try:
+		oauth_data = await get_oauth_data(page)
+		await context.route(f'{PROVIDER_ORIGIN}/**', capture_oauth_callback)
+		oauth_url = 'https://github.com/login/oauth/authorize?' + urlencode(
+			{
+				'response_type': 'code',
+				'client_id': oauth_data['client_id'],
+				'state': oauth_data['state'],
+				'scope': 'user:email',
+			}
+		)
+		await goto_document(page, oauth_url)
+
+		login_field = await page.query_selector('#login_field')
+		if login_field:
+			print(f'[{name}] filling GitHub login')
+			await login_field.fill(username)
+			await page.fill('#password', password)
+			await page.click('input[name="commit"], input[type="submit"][value="Sign in"]')
+			await wait_for_settle(page, timeout=15000)
+
+		await fill_totp_if_needed(page, account)
+
+		if 'github.com/login/oauth/authorize' in page.url:
+			try:
+				clicked = await safe_click_authorize(page)
+			except Exception as exc:
+				if 'Execution context was destroyed' not in str(exc):
+					raise
+				clicked = 'navigation'
+			print(f'[{name}] authorize click: {clicked or "not needed"}')
+			if clicked:
+				await wait_for_settle(page, timeout=15000)
+
+		for _ in range(60):
+			remember_url(page.url)
+			if callback_urls:
+				break
+			await page.wait_for_timeout(1000)
+		await page.wait_for_timeout(3000)
+
+		print(f'[{name}] final url: {scrub_url(page.url)}')
+		query = oauth_query(callback_urls[-1]) if callback_urls else oauth_query(page.url)
+		if not query:
+			print(f'[{name}] OAuth callback code not found')
+			return False
+
+		await context.unroute(f'{PROVIDER_ORIGIN}/**', capture_oauth_callback)
+		callback_path = f'/api/oauth/github?{urlencode(query, doseq=True)}'
+		callback = await browser_json(page, callback_path, headers={'Accept': 'application/json, text/plain, */*'})
+		callback_data = callback['data']
+		print(
+			f"[{name}] oauth api: {{'status': {callback['status']}, "
+			f"'success': {callback_data.get('success')}, 'has_data': {bool(callback_data.get('data'))}}}"
+		)
+		if callback['status'] != 200 or not callback_data.get('success'):
+			print(
+				f'[{name}] oauth callback failed: {callback_data.get("message") or callback_data.get("msg") or "unknown"}'
+			)
+			return False
+
+		api_user = str(callback_data.get('data', {}).get('id') or '')
+		if not api_user:
+			print(f'[{name}] api user missing from callback')
+			return False
+
+		headers = {
+			'Accept': 'application/json, text/plain, */*',
+			'Origin': PROVIDER_ORIGIN,
+			'Referer': PROVIDER_ORIGIN,
+			'new-api-user': api_user,
+		}
+		user_resp = await browser_json(page, '/api/user/self', headers=headers)
+		user_data = user_resp['data']
+		print(
+			f"[{name}] user/self: {{'status': {user_resp['status']}, "
+			f"'success': {user_data.get('success')}, 'has_data': {bool(user_data.get('data'))}}}"
+		)
+		if user_resp['status'] != 200 or not user_data.get('success'):
+			return False
+
+		sign_headers = {**headers, 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}
+		sign_resp = await browser_json(page, '/api/user/sign_in', method='POST', headers=sign_headers)
+		sign = sign_resp['data']
+		print(
+			f"[{name}] sign_in: {{'status': {sign_resp['status']}, "
+			f"'success': {sign.get('success')}, 'ret': {sign.get('ret')}, 'code': {sign.get('code')}, "
+			f"'message': {sign.get('message') or sign.get('msg') or ''!r}}}"
+		)
+		ok = sign_resp['status'] == 200 and (
+			sign.get('success') is True
+			or sign.get('ret') == 1
+			or sign.get('code') == 0
+			or '已' in (sign.get('message') or sign.get('msg') or '')
+		)
+		if ok:
+			state_path.write_text(
+				json.dumps(github_only_storage_state(await context.storage_state())), encoding='utf-8'
+			)
+			state_path.chmod(0o600)
+			print(f'[{name}] success')
+		return ok
+	except Exception as exc:
+		print(f'[{name}] failed: {exc}')
+		return False
+	finally:
+		await context.close()
+		await browser.close()
+
+
+async def main() -> int:
+	accounts = load_accounts()
+	only = {item.strip() for item in os.getenv('ACCOUNT_ONLY', '').split(',') if item.strip()}
+	if only:
+		accounts = [
+			account for account in accounts if account.get('name') in only or account.get('github_username') in only
+		]
+		if not accounts:
+			print('summary: success=0, failed=0')
+			print('no accounts matched ACCOUNT_ONLY')
+			return 1
+	elif os.getenv('ACCOUNT_ORDERED', '').lower() not in {'1', 'true', 'yes', 'on'}:
+		random.shuffle(accounts)
+		print('account order randomized')
+
+	limit = int(os.getenv('ACCOUNT_LIMIT', str(len(accounts))))
+	no_delay = '--no-delay' in sys.argv
+	success = 0
+	failed = 0
+
+	if not no_delay and START_DELAY_MAX_SECONDS > 0:
+		start_delay = random.randint(0, START_DELAY_MAX_SECONDS)
+		print(f'startup random delay: {start_delay}s')
+		await asyncio.sleep(start_delay)
+
+	async with async_playwright() as playwright:
+		for index, account in enumerate(accounts[:limit]):
+			if index > 0 and not no_delay:
+				delay = random.randint(ACCOUNT_DELAY_MIN_SECONDS, ACCOUNT_DELAY_MAX_SECONDS)
+				print(f'delay before next account: {delay}s')
+				await asyncio.sleep(delay)
+			ok = await check_account(playwright, account, index)
+			if ok:
+				success += 1
+			else:
+				failed += 1
+
+	print(f'summary: success={success}, failed={failed}')
+	return 0 if success > 0 and failed == 0 else 1
+
+
+if __name__ == '__main__':
+	raise SystemExit(asyncio.run(main()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
   "httpx[http2]>=0.24.0",
   "cloakbrowser>=0.3.0",
+  "playwright>=1.55.0",
   "python-dotenv>=1.0.0"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -23,6 +23,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "cloakbrowser" },
     { name = "httpx", extra = ["http2"] },
+    { name = "playwright" },
     { name = "python-dotenv" },
 ]
 
@@ -43,6 +44,7 @@ dev = [
 requires-dist = [
     { name = "cloakbrowser", specifier = ">=0.3.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.24.0" },
+    { name = "playwright", specifier = ">=1.55.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 


### PR DESCRIPTION
## Summary
- add an optional Playwright-based `checkin_github_oauth.py` path for AnyRouter GitHub OAuth + TOTP check-in
- add a dedicated `AnyRouter GitHub OAuth 自动签到` workflow that reads `ANYROUTER_GITHUB_ACCOUNTS`, caches GitHub OAuth state, and supports manual account filtering
- document the OAuth/TOTP mode, including attribution to https://github.com/liukaizheng/anyrouter-check-in and its GitHub OAuth session acquisition flow/TOTP notes

## Compatibility
- the existing `AnyRouter 自动签到` workflow is not modified
- the new OAuth workflow defaults to `workflow_dispatch` only, so it will not add another scheduled job for existing users
- users who want scheduled GitHub OAuth check-in can add `schedule` to `.github/workflows/github-oauth-checkin.yml` after configuring `ANYROUTER_GITHUB_ACCOUNTS`

## Notes
This keeps the existing cookie/email-password provider flow intact. The new path is optional and focused on GitHub OAuth accounts. Compared with `liukaizheng/anyrouter-check-in`, this implementation is Python/Playwright-based and fits this repository's existing dependency and workflow structure.

## Verification
- `uv run ruff check checkin_github_oauth.py`
- `python3 -m py_compile checkin_github_oauth.py`
- workflow YAML parsed with PyYAML
- `uv run pytest` -> 20 passed, 1 skipped
