### PR TITLE
fix: agentrouter 浏览器登录后签到流程修复

### DIFF
--- a/checkin.py
+++ b/checkin.py
@@ -219,12 +219,25 @@ async def login_with_credentials(
 		}
 		api_user = str(user_profile['id']) if user_profile.get('id') is not None else None
 
+		user_info = None
+		quota_raw = user_profile.get('quota', 0)
+		used_raw = user_profile.get('used_quota', 0)
+		if quota_raw or used_raw:
+			quota = round(quota_raw / 500000, 2)
+			used_quota = round(used_raw / 500000, 2)
+			user_info = {
+				'success': True,
+				'quota': quota,
+				'used_quota': used_quota,
+				'display': f':money: Current balance: ${quota}, Used: ${used_quota}',
+			}
+
 		success_msg = f'[SUCCESS] {account_name}: Login successful, got {len(all_cookies)} cookies'
 		if is_debug_enabled() and api_user:
 			success_msg += f', api_user={api_user}'
 		print(success_msg)
 		await context.close()
-		return BrowserLoginResult(cookies=all_cookies, api_user=api_user)
+		return BrowserLoginResult(cookies=all_cookies, api_user=api_user, user_info=user_info)
 
 	except Exception as e:
 		print(f'[FAILED] {account_name}: Error during login: {e}')
@@ -380,6 +393,14 @@ async def check_in_account(account: AccountConfig, account_index: int, app_confi
 			all_cookies = login_result.cookies
 			resolved_api_user = login_result.api_user
 			auth_method = 'email/password'
+
+			if not provider_config.needs_manual_check_in():
+				user_info = login_result.user_info
+				if user_info and user_info.get('success'):
+					print(f'[INFO] {account_name}: Check-in completed during browser login')
+					print(user_info['display'])
+					return True, None, user_info
+				return False, None, None
 		else:
 			print(f'[FAILED] {account_name}: Email/password login failed, will not use stale session cookies')
 			return False, None, None

--- a/utils/browser.py
+++ b/utils/browser.py
@@ -143,6 +143,7 @@ _OPEN_EMAIL_FORM_JS = """() => {
 class BrowserLoginResult:
 	cookies: dict[str, str]
 	api_user: str | None = None
+	user_info: dict | None = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## 问题

AgentRouter 的签到不是在调用 /api/user/self 时自动触发的，而是在浏览器登录时由服务端触发。当前代码用 CloakBrowser 完成邮箱密码登录后，erify_browser_login() 已经拦截到了 /api/user/self 的响应（包含余额数据），但 login_with_credentials() 只提取了 id，丢弃了余额信息。然后继续走 un_check_in_requests() 用 httpx 重新调 API——这个 httpx 请求不会触发签到，且脱离浏览器上下文后 WAF cookies 可能失效。

## 修改

1. **utils/browser.py** — BrowserLoginResult 增加 user_info 字段
2. **checkin.py — login_with_credentials()** — 从浏览器响应中提取余额
3. **checkin.py — check_in_account()** — agentrouter 跳过 httpx 路径，直接返回浏览器余额

Ref: https://github.com/millylee/anyrouter-check-in/issues/45 https://github.com/millylee/anyrouter-check-in/issues/115